### PR TITLE
feat: add rle file reader

### DIFF
--- a/src/cholerama/helpers.py
+++ b/src/cholerama/helpers.py
@@ -65,3 +65,41 @@ class Positions:
 
     def __len__(self):
         return len(self.x)
+
+
+def read_rle(fpath):
+    with open(fpath) as f:
+        lines = [line for line in f.readlines() if not line.startswith('#')]
+    xs = []
+    ys = []
+    digits_next_repeat = ''
+    x = 0
+    y = 0
+    # Skip one line containing bounding box
+    for line in lines[1:]:
+        for c in line:
+            if c in '0123456789':
+                digits_next_repeat += c
+                continue
+            if c in 'bo$':
+                repeat = (
+                    1 if digits_next_repeat == ''
+                    else int(digits_next_repeat)
+                )
+                if c == 'b':
+                    x += repeat 
+                elif c == 'o':
+                    for _ in range(repeat):
+                        xs.append(x)
+                        ys.append(y)
+                        x += 1
+                elif c == '$':
+                    y += repeat
+                    x = 0
+                digits_next_repeat = ''
+            if c == '!':
+                return Positions(
+                    x=np.array(xs, dtype='int'),
+                    y=np.array(ys, dtype='int')
+                )
+    raise ValueError(f'{fpath} is not a well formatted rle file')

--- a/src/cholerama/helpers.py
+++ b/src/cholerama/helpers.py
@@ -67,7 +67,7 @@ class Positions:
         return len(self.x)
 
 
-def read_rle(fpath):
+def read_rle(fpath: str) -> Positions:
     with open(fpath) as f:
         lines = [line for line in f.readlines() if not line.startswith('#')]
     xs = []


### PR DESCRIPTION
Adds a helper for reading `rle` (run length encoding) files encoding game of life patterns.

Usage example:
```python
from cholerama import helpers

def path_to_local_file(fname):
    return os.path.join(os.path.dirname(__file__), fname)

# Returns a Positions object
positions = helpers.read_rle(path_to_local_file('glider.rle'))
```

Some example `rle` files:
```
#C glider.rle
#C This is a glider.
x = 3, y = 3
bo$2bo$3o!
```
or
```
#N Gosper glider gun
#O Bill Gosper
#C A true period 30 glider gun.
#C The first known gun and the first known finite pattern with unbounded growth.
#C www.conwaylife.com/wiki/index.php?title=Gosper_glider_gun
x = 36, y = 9, rule = B3/S23
24bo11b$22bobo11b$12b2o6b2o12b2o$11bo3bo4b2o12b2o$2o8bo5bo3b2o14b$2o8b
o3bob2o4bobo11b$10bo5bo7bo11b$11bo3bo20b$12b2o!
```